### PR TITLE
Load save with spatial domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ incidenceMapR_*.tar.gz
 modelDB.tsv
 test_model_store/*
 .idea/
+plots/*

--- a/README.md
+++ b/README.md
@@ -21,52 +21,57 @@ Incidence-mapper exists to perform three different classes of routine tasks on e
 - **quantify effects of factors** on outcomes using generalized linear regression, after adjusting for confounders (ie covariates that aren't of interest).  This is useful for individual-level understanding of things like vaccine efficacy, and for predicting individual priors for DeDx based on measured covariates. This is not a priority for April as it applies to individuals and isn't the fundamental "flu map".
 
 
-## To-do on simulated data
-Currently, this service pulls data from seattleflu/simulated-data.  There are remaining tasks to finish before swapping over to live data:
+# Models that demo_deployment
 
-- hook api_service to modelServR **OR** jettison R connection and handle modelServR tasks solely in python layer. 
-- **incidenceMapR** needs a ton of work
-  - build model definitions for modelTrainR with
-    - modelEffects
-      - write function etc
-  - **saveModel** improvements
-    - generalize to output fitted.values, coefficients, and latent fields
-    - repoint to a more accessible data store. 
-    - improve description database for better lookup.
+These model csvs obey the format that will go up on the deployed model server (subject to revision if requested by viz team).  The older models in parallel directories are obsolete, but I've kept them to avoid breaking prototypes.
 
-- **modelServR**
-  - in coordination with incidenceMapR::saveModel, we need a better model lookup API.  Some sort of artifact storage and recall tool. 
-  - it needs to know about both smoothing and latent-field models (to come)
-  - what format does Antonio want back? Flat or nested json? (R prefers flat.)
-  
-# To-do to swap over to live data
+## Model definition
+Models are defined by:
+- the pathogen of interest, either a specific one from the database (assuming it gets populated..., like `FLU_A_H1` or `h3n2`) or `all` (for all samples regardless of pathogen), or `unknown` (the default I have until the taqman data is made available).
+- the strata (/facets/covariates), like `[encountered_week, residence_puma]` or `[flu_shot, residence_census_tract]`
+- either the type of model (`observed` or `latent`), or, if that makes little sense on your end, the outcome you want models of, like (`count` and `fraction` (observed), or `intensity` (latent)).
 
-## dbViewR
+## Timeseries models
+All examples included in this commit are timeseries models by `encountered_week`.  Both model types need not include time in general, but all the ones for May 22 will.  To collapse over time to produce a static map, it is approximately valid to average outcomes over time. Long-term, there are more interesting, and more correct, things to do, but that's not bad and retains interesting meaning for people exploring the data.
 
-- dbViewR::selectFromDB connect to research DB at Hutch
-    - this should probably just be replaced with a SQL query handle to the database that pulls specified views into R, instead of all this dplyr junk. 
-- dbViewR::masterSpatialDB connect to shapefiles repo and add option to call different levels of aggregation.
-    - am I happy with our geo_jsons?  Consider updated canonical set. 
-- dbViewR::expandDB needs to know about permitted columns from real database and rules for table expansion.
-    - get database schema from Hutch. 
+### `Observed` models
+`Observed` models are interpolations and extrapolations from the observed data.  For the purposes of visualization, these models complement raw data summaries in two ways:
+1.  They use the statistical properties of the entire sample to regularize estimates for small areas and times. This goes by many names in the statistical modeling literature, but two useful ones are "partial pooling" for  "small area estimation".  The benefit of partially-pooled estimates is they reduce the influence of small sample statistics on visual outlier detection. (For example, we shouldn't really believe that places with no measurements have no incidence.)
+2.  For human comprehension, they "fill in the map" to emphasize larger-scale patterns that are more likely to be real (as in, there's a lot of aggregate evidence) and down-play local variation for small samples.  This aspect will be useful for understanding where and when we gathered data, so we can rationally plan to expand next year.
 
-## modelServR
-- Define API with James, Antonio, and Thomas.
-  - We intend to ship models as JSON blobs.
-  - We will propose some example JSON queries to request model blobs soon. 
+The `observed` models in this repo are faceted by factors about our participants, like `site_type` (where the sample was taken), `sex` (male or female), and `flu_shot` (self-reported "have you had flu vaccine in last year?" or records, 1=yes, 0=no). It would be nice to have a selector for factors to facet by, but tell me if you want the deployed models to have fewer facets.  From point of view, the only non-negotiable facet is `site_type` as differences in the total counts and residence locations captured by our different collection modes are very important to our study partners for understanding what we collected this year.
 
-# To-do to improve science
+### `Latent` field models
+`Latent` field models represent an inference of the underlying force of infection in the total population over space and time, after adjusting for features of our sampling process and factors associated with our participants. The "latent field" is estimated during the estimation of the observed models above.  It represents a model of the residual variation in the data that is not explained by observed factors like `site_type`, `sex`, or `flu_shot`.  From the inferred latent field, we can produce an output I'm calling `modeled_intensity` which is an un-normalized estimate of total population incidence.  I'm not yet producing normalized incidence estimates because we (1) haven't linked to census population data yet and (2) haven't worked out what we can about "denominator data" for our sample (what fraction of people who could've participated were sick enough to partipate and willing to enroll?).  Regardless, the relative information in the `modeled_intensity`, both in time and space, can be interpreted similarly to true incidence, and through the modeled intensity, we get a picture of the dynamics of transmission. 
 
-- **Provide science documentation**: what are the models (in equations) and what do they do?
- 
-## across all R packages
-- incorporate census demographic data
-  - locate appropriate data source
-  - add query and formatting to dbViewR
-  - incorporate in incidenceModelR where appropriate
-  
-## incidenceMapR
+The most important thing the latent field model adjusts for is an estimate of the "catchment" of each `site_type`. The catchment of each site estimates how likely people at each residence location are to have participated in our study, independent of if they are sick with the pathogen of interest.  
+For example, to estimate the catchment of `kiosk` collection for `h1n1pdm`, we infer a `observed` model for the expected number of participants in each residence location  *with all non-h1n1pdm infections* who partipate in kiosk sampling, aggegrated over the entire study duration (no time-dependence).  We take this as a measure of the rate at which people would interact with a kiosk, independent of being sick with `h1n1pdm`, the pathogen of interest, and averaged over the variations in space and time of the many other pathogens that also drive participation.  
+The key assumptions are that (1) averaging of pathogen dynamics that are (2) independent of the specific pathogen being modeled reveals the underlying acces to kiosks and willingness to participate of people in each mapped residence location. 
+
+Given the estimated catchment of each `site_type`, the observed number of `h1n1pdm` cases over space and time are modeled relative to the catchment.  In places where we get a lot of samples for lots of reasons, a few `h1n1pdm` samples represents a low intesity of transmission.  But in places where we get few samples other than `h1n1pdm`, we infer that flu intensity at that residence location and time is high.  The latent field model collectively estimates this intensity across the whole map, thus inferred space-time properties of the total population epidemic. 
+
+
+# After May 22 demo
+
+## Provide science documentation
+What are the models (in words, equations, and code) and what do they do?
+
+## Time-independent models
+Instead of averaging over time in the client, we should model various time averages and time slices directly, corresponding to different cognitive tasks. I can generate many of these now, but I'm not expecting the viz to request them.
+
+## Age-dependent models
+Depending on the outcome of interest, age is either like a factor or like time, and so the models and viz will need to depend on the cognitive task.
+
+## Vaccine-efficacy models
+These will be an example of a different cognitive task, where the inference of interest is a parameter and not a direct transformation of data.  Line, bar, and map chart viz components will likely be similar, but context will need to be different.  This and other intervention effectiveness summaries will be really important for Year 2. 
+
+## Incorporate census demographic data
+- locate appropriate data source
+- add query and formatting to dbViewR
+- incorporate in incidenceModelR where appropriate
+
+## incidenceMapR improvements
 - adjacency networks
   - define lowest spatial scale based on based shapes, instead of residence_census_tract (census tract) only
   - allow adjacency network models beyond default contiguous nearest-neighbor
-
+- many more!

--- a/buildModelsForDeployment.R
+++ b/buildModelsForDeployment.R
@@ -22,8 +22,8 @@ pathogens <- c('all', unique(db$observedData$pathogen))
 factors   <- c('site_type','sex','flu_shot')
 
 geoLevels <- list( seattle_geojson = c('residence_puma','residence_neighborhood_district_name','residence_cra_name','residence_census_tract'),
-                   wa_geojson = c('residence_puma'), # census tract impossible due to memory limits
-                   king_county_geojson = c('residen#ce_census_tract')
+                   wa_geojson = c('residence_puma')#, # census tract impossible due to memory limits
+                   #king_county_geojson = c('residence_census_tract')
                  )
 
 

--- a/buildModelsForDeployment.R
+++ b/buildModelsForDeployment.R
@@ -21,9 +21,9 @@ db <- selectFromDB(queryIn= list(SELECT  =c("*")), source = SRC)
 pathogens <- c('all', unique(db$observedData$pathogen))
 factors   <- c('site_type','sex','flu_shot')
 
-geoLevels <- list( seattle_geojson = c('residence_neighborhood_district_name','residence_cra_name'),
+geoLevels <- list( seattle_geojson = c('residence_puma','residence_neighborhood_district_name','residence_cra_name','residence_census_tract'),
                    wa_geojson = c('residence_puma'), # census tract impossible due to memory limits
-                   king_county_geojson = c('residence_census_tract')
+                   king_county_geojson = c('residen#ce_census_tract')
                  )
 
 #####################################
@@ -47,30 +47,36 @@ for (SOURCE in names(geoLevels)){
       db <- expandDB( selectFromDB(  queryIn, source=SRC, na.rm=TRUE ), shp=shp )
       
       # training occassionaly segfaults on but it does not appear to be deterministic...
-      tryCatch(
-        {
-          
-          db <- appendCatchmentModel(db,shp=shp, source=SRC, na.rm=TRUE  )
-          
-          modelDefinition <- latentFieldModel(db=db, shp=shp)
-          model <- modelTrainR(modelDefinition)
-          
-          print(summary(model$inla))
-          
-          saveModel(model)
-          
-          dir.create('/home/rstudio/seattle_flu/plots/', showWarnings = FALSE)
-          fname <- paste('/home/rstudio/seattle_flu/plots/',paste(PATHOGEN,SOURCE,paste(factors,collapse='-'),GEO,'encountered_week',sep='-'),'.png',sep='')
-          png(filename = fname,width = 6, height = 5, units = "in", res = 300)
-          print(ggplot(model$latentField) + 
-                  geom_line(aes_string(x='encountered_week',y="modeled_intensity_mode", color=GEO,group =GEO)) + 
-                  # geom_ribbon(aes_string(x='encountered_week',ymin="modeled_intensity_lower_95_CI", ymax="modeled_intensity_upper_95_CI", fill=GEO,group =GEO),alpha=0.1) + 
-                  guides(color=FALSE) )
-          dev.off()
-          
-        }, error=function(e){cat("ERROR :",conditionMessage(e), "\n")}
-      )
-      
+      tries <- 0
+      success<-0
+      while (success==0 & tries<=2){
+        tries <- tries+1
+        tryCatch(
+          {
+            
+            db <- appendCatchmentModel(db,shp=shp, source=SRC, na.rm=TRUE  )
+            
+            modelDefinition <- latentFieldModel(db=db, shp=shp)
+            model <- modelTrainR(modelDefinition)
+            
+            print(summary(model$inla))
+            
+            saveModel(model)
+            
+            dir.create('/home/rstudio/seattle_flu/plots/', showWarnings = FALSE)
+            fname <- paste('/home/rstudio/seattle_flu/plots/',paste(PATHOGEN,SOURCE,paste(factors,collapse='-'),GEO,'encountered_week',sep='-'),'.png',sep='')
+            png(filename = fname,width = 6, height = 5, units = "in", res = 300)
+            print(ggplot(model$latentField) + 
+                    geom_line(aes_string(x='encountered_week',y="modeled_intensity_mode", color=GEO,group =GEO)) + 
+                    # geom_ribbon(aes_string(x='encountered_week',ymin="modeled_intensity_lower_95_CI", ymax="modeled_intensity_upper_95_CI", fill=GEO,group =GEO),alpha=0.1) + 
+                    guides(color=FALSE) )
+            dev.off()
+            
+            success<-1
+            
+          }, error=function(e){cat("ERROR :",conditionMessage(e), "\n")}
+        )
+      }
     }
   }
 }

--- a/modelServR/R/returnModel.R
+++ b/modelServR/R/returnModel.R
@@ -44,10 +44,10 @@ loadModelFileById <- function (filename, model_store_dir = Sys.getenv('MODEL_STO
 #'
 returnModel <- function(queryIn = jsonlite::toJSON(
                               list(
-                                SELECT   =list(COLUMN=c('site_type','residence_census_tract')),
-                                WHERE   =list(COLUMN='site_type', IN = c('kiosk')),
+                                SELECT   =list(COLUMN=c('pathogen','site_type','residence_census_tract')),
+                                WHERE   =list(COLUMN='pathogen', IN = 'all'),
                                 GROUP_BY =list(COLUMN=c('site_type','residence_census_tract')),
-                                SUMMARIZE=list(COLUMN='site_type', IN= c('kiosk'))
+                                SUMMARIZE=list(COLUMN='pathogen', IN= 'all')
                                   )),
                             type = 'observed',
                             version = 'latest',

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -21,7 +21,8 @@ getHumanReadableModelIdFromQuery <- function(query) {
   result <- tolower(sprintf("%s-%s-%s",
                             paste(props$model_type,collapse = "."),
                             paste(props$pathogen, collapse = "."),
-                            paste(props$observed, collapse = ".")))
+                            paste(props$observed, collapse = "."),
+                            paste(props$spatial_domain, collapse = ".")))
   return(result)
 }
 

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -164,27 +164,23 @@ saveModel <- function(model, modelStoreDir =  Sys.getenv('MODEL_STORE', '/home/r
   #ensure our model store directory exists
   dir.create(modelStoreDir, showWarnings = FALSE)
   
-  # all models output inla
+  loginfo("Saving smooth model")
+  # all models output smooth
+  modelQuery <- getModelQueryObjectFromModel(model, latent = FALSE)
+  modelId <- getModelIdFromQuery(modelQuery)
+  name <- getHumanReadableModelIdFromModel(model, latent = FALSE)
+  filename <-modelId
   newRow <- data.frame(
     filename = filename,
     name = name,
     queryJSON = as.character(jsonlite::toJSON(modelQuery)),
-    type = 'inla',
+    type = 'inla_observed',
     created = ts
   )
-
-  if (storeRDS) {
-    loginfo("Saving RDS")
-    outfile <- xzfile(paste(modelStoreDir, '/', filename, '.RDS', sep = ''), 'wb', compress=9, encoding = 'utf8')
-    saveRDS(model,file = outfile)
-    close(outfile)
-  }
-  
-
-  loginfo("Saving smooth model")
-  # all models output smooth
-  newRow$type <- 'inla_observed'
   newRow$latent <- FALSE
+  
+  print("Saving observed model")
+  
   write.csv(
     model$modeledData,
     paste(modelStoreDir, '/', filename, '.csv', sep = ''),
@@ -196,6 +192,7 @@ saveModel <- function(model, modelStoreDir =  Sys.getenv('MODEL_STORE', '/home/r
     quote = FALSE, append = file.exists(modelDBfilename)
   )
   
+
   # If we have a latent_field type, write out that csv
   if (model$modelDefinition$type == 'latent_field') {
     modelQuery <- getModelQueryObjectFromModel(model, latent = TRUE)
@@ -226,6 +223,15 @@ saveModel <- function(model, modelStoreDir =  Sys.getenv('MODEL_STORE', '/home/r
       quote = FALSE, append = file.exists(modelDBfilename)
     )
   }
+  
+  # all models output inla objects of smooth/observed or latent types
+  if (storeRDS) {
+    loginfo("Saving RDS")
+    outfile <- xzfile(paste(modelStoreDir, '/', filename, '.RDS', sep = ''), 'wb', compress=9, encoding = 'utf8')
+    saveRDS(model,file = outfile)
+    close(outfile)
+  }
+  
 }
 
 

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -109,7 +109,7 @@ getModelQueryObjectFromQuery <- function(query) {
 #'
 #' @export
 #'
-getModelIdFromModel <- function(mode, model_type = 'inla_observed', latent = FALSEl) {
+getModelIdFromModel <- function(mode, model_type = 'inla', latent = FALSE) {
   return(getModelIdFromQuery(getModelQueryObjectFromModel(model, model_type, latent)))
 }
 
@@ -195,7 +195,7 @@ saveModel <- function(model, modelStoreDir =  Sys.getenv('MODEL_STORE', '/home/r
   
   # If we have a latent_field type, write out that csv
   if (model$modelDefinition$type == 'latent_field') {
-    modelQuery <- getModelQueryObjectFromModel(model, TRUE)
+    modelQuery <- getModelQueryObjectFromModel(model, latent = TRUE)
     modelId <- getModelIdFromQuery(modelQuery)
     name <- getHumanReadableModelIdFromModel(model)
     filename <-modelId

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -96,7 +96,7 @@ getModelQueryObjectFromQuery <- function(query) {
   result$observed <- sort(query$observed)
   result$model_type <- query$model_type
   result$pathogen <- query$pathogen
-  result$spatial_domain <- query$spatialDomain
+  result$spatial_domain <- query$spatial_domain
   
   logdebug("getModelQueryObjectFromQuery result:", str(result))
   return(result)

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -18,7 +18,7 @@ getHumanReadableModelIdFromModel <- function(model, latent = FALSE) {
 #'
 getHumanReadableModelIdFromQuery <- function(query) {
   props <- getModelQueryObjectFromQuery(query)
-  result <- tolower(sprintf("%s-%s-%s",
+  result <- tolower(sprintf("%s-%s-%s-%s",
                             paste(props$model_type,collapse = "."),
                             paste(props$pathogen, collapse = "."),
                             paste(props$observed, collapse = "."),

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -5,8 +5,8 @@
 #' @return Unique String representing model in human readable format
 #' @export
 #'
-getHumanReadableModelIdFromModel <- function(model) {
-  return (getHumanReadableModelIdFromQuery(getModelQueryObjectFromModel(model)))
+getHumanReadableModelIdFromModel <- function(model, latent = FALSE) {
+  return (getHumanReadableModelIdFromQuery(getModelQueryObjectFromModel(model, latent)))
 }
 
 #' getHumanReadableModelIdFromQuery: return human readable verion of model from query
@@ -36,7 +36,7 @@ getHumanReadableModelIdFromQuery <- function(query) {
 #' @return An object containing the observed and the model_type fields
 #' @export
 #'
-getModelQueryObjectFromModel<- function(model, model_type = 'inla_observed', latent = FALSE) {
+getModelQueryObjectFromModel<- function(model, latent = FALSE) {
 
   result <- newEmptyObject()
   if (latent) {
@@ -44,7 +44,7 @@ getModelQueryObjectFromModel<- function(model, model_type = 'inla_observed', lat
     validColumnNames <- sort(colnames(model$modelDefinition$latentFieldData))
     
   } else {
-    result$model_type <- jsonlite::unbox(model_type)
+    result$model_type <- jsonlite::unbox('inla_observed')
     validColumnNames <- sort(colnames(model$modelDefinition$observedData))
   }
     
@@ -70,7 +70,7 @@ getModelQueryObjectFromModel<- function(model, model_type = 'inla_observed', lat
   }
   
   # grab spatial_domain from modelDefinition
-  result$spatial_domain <- model$modelDefinition$spatial_domain
+  result$spatial_domain <- model$modelDefinition$spatialDomain[1]
   
   logdebug("Result: ", result)
   return(result)
@@ -197,7 +197,7 @@ saveModel <- function(model, modelStoreDir =  Sys.getenv('MODEL_STORE', '/home/r
   if (model$modelDefinition$type == 'latent_field') {
     modelQuery <- getModelQueryObjectFromModel(model, latent = TRUE)
     modelId <- getModelIdFromQuery(modelQuery)
-    name <- getHumanReadableModelIdFromModel(model)
+    name <- getHumanReadableModelIdFromModel(model, latent = TRUE)
     filename <-modelId
     newRow <- data.frame(
       filename = filename,

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -128,8 +128,8 @@ getModelIdFromQuery <- function(query) {
   setLevel("FINEST")
 
   #props <- getModelQueryObjectFromQuery(query)
-  modelId <- as.character(jsonlite::toJSON(query, simplifyDataFrame=))
-  logdebug("Model ID JSON:", jsonlite::toJSON(query, simplifyDataFrame=))
+  modelId <- as.character(jsonlite::toJSON(query))
+  logdebug("Model ID JSON:", jsonlite::toJSON(query))
   modelId <- digest::digest(modelId, serialize=FALSE)
   logdebug("Model ID Hash:", modelId)
   return(modelId)

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -96,7 +96,7 @@ getModelQueryObjectFromQuery <- function(query) {
   result$observed <- sort(query$observed)
   result$model_type <- query$model_type
   result$pathogen <- query$pathogen
-  result$spatial_domain <- query$spatial_domain
+  result$spatial_domain <- query$spatialDomain
   
   logdebug("getModelQueryObjectFromQuery result:", str(result))
   return(result)

--- a/modelServR/R/saveModel.R
+++ b/modelServR/R/saveModel.R
@@ -22,7 +22,7 @@ getHumanReadableModelIdFromQuery <- function(query) {
                             paste(props$model_type,collapse = "."),
                             paste(props$pathogen, collapse = "."),
                             paste(props$observed, collapse = "."),
-                            paste(props$spatial_domain, collapse = ".")))
+                            paste(props$spatial_domain, collapse = ".")))  # paste(paste()) would be easier to maintain, but I'm leaving this for now
   return(result)
 }
 

--- a/modelServR/man/getHumanReadableModelIdFromModel.Rd
+++ b/modelServR/man/getHumanReadableModelIdFromModel.Rd
@@ -4,7 +4,7 @@
 \alias{getHumanReadableModelIdFromModel}
 \title{getHumanReadableModelIdFromModel: return human readable verion of model from query}
 \usage{
-getHumanReadableModelIdFromModel(model)
+getHumanReadableModelIdFromModel(model, latent = FALSE)
 }
 \arguments{
 \item{model}{INLA model object that will generatie id from}

--- a/modelServR/man/getModelIdFromModel.Rd
+++ b/modelServR/man/getModelIdFromModel.Rd
@@ -4,7 +4,7 @@
 \alias{getModelIdFromModel}
 \title{getModelIdFromModel: function to get model id from a model objejct}
 \usage{
-getModelIdFromModel(mode, model_type = "inla", latent = FALSEl)
+getModelIdFromModel(mode, model_type = "inla", latent = FALSE)
 }
 \arguments{
 \item{model_type}{String of model type}

--- a/modelServR/man/getModelQueryObjectFromModel.Rd
+++ b/modelServR/man/getModelQueryObjectFromModel.Rd
@@ -5,15 +5,14 @@
 \title{getModelQueryObjectFromModel: return query object from a model.
 This is the object we use to generate our unique ids.}
 \usage{
-getModelQueryObjectFromModel(model, model_type = "inla",
-  latent = FALSE)
+getModelQueryObjectFromModel(model, latent = FALSE)
 }
 \arguments{
 \item{model}{= Model object to get query object for}
 
-\item{model_type}{= Model Type string. Default to inla}
-
 \item{latent}{= Bool determing if we are saving a latent model or a smooth model}
+
+\item{model_type}{= Model Type string: 'inla_observed' (default) or 'inla_latent'}
 }
 \value{
 An object containing the observed and the model_type fields

--- a/modelServR/man/returnModel.Rd
+++ b/modelServR/man/returnModel.Rd
@@ -8,14 +8,14 @@ returnModel(queryIn = jsonlite::toJSON(list(SELECT = list(COLUMN =
   c("site_type", "residence_census_tract")), WHERE = list(COLUMN =
   "site_type", IN = c("kiosk")), GROUP_BY = list(COLUMN = c("site_type",
   "residence_census_tract")), SUMMARIZE = list(COLUMN = "site_type", IN =
-  c("kiosk")))), type = "smooth", version = "latest",
+  c("kiosk")))), type = "observed", version = "latest",
   cloudDir = Sys.getenv("MODEL_STORE",
   "/home/rstudio/seattle_flu/test_model_store"))
 }
 \arguments{
 \item{queryIn}{JSON query to dbViewR that defines model}
 
-\item{type}{= "smooth" (default), "latent_field", "effects", "inla"}
+\item{type}{= "inla_observed" (default), "inla_latent", "inla"}
 
 \item{version}{= "latest" (default) or ISO date and time created (UTC, like "2019-04-19 22:49:19Z")}
 

--- a/modelServR/man/returnModel.Rd
+++ b/modelServR/man/returnModel.Rd
@@ -5,10 +5,10 @@
 \title{returnModel function for getting modeled data}
 \usage{
 returnModel(queryIn = jsonlite::toJSON(list(SELECT = list(COLUMN =
-  c("site_type", "residence_census_tract")), WHERE = list(COLUMN =
-  "site_type", IN = c("kiosk")), GROUP_BY = list(COLUMN = c("site_type",
-  "residence_census_tract")), SUMMARIZE = list(COLUMN = "site_type", IN =
-  c("kiosk")))), type = "observed", version = "latest",
+  c("pathogen", "site_type", "residence_census_tract")), WHERE =
+  list(COLUMN = "pathogen", IN = "all"), GROUP_BY = list(COLUMN =
+  c("site_type", "residence_census_tract")), SUMMARIZE = list(COLUMN =
+  "pathogen", IN = "all"))), type = "observed", version = "latest",
   cloudDir = Sys.getenv("MODEL_STORE",
   "/home/rstudio/seattle_flu/test_model_store"))
 }

--- a/modelServR/man/saveModel.Rd
+++ b/modelServR/man/saveModel.Rd
@@ -5,7 +5,7 @@
 \title{saveModel: function to save models and register them in modelDB.csv}
 \usage{
 saveModel(model, modelStoreDir = Sys.getenv("MODEL_STORE",
-  "/home/rstudio/seattle_flu/test_model_store"))
+  "/home/rstudio/seattle_flu/test_model_store"), storeRDS = TRUE)
 }
 \arguments{
 \item{model}{INLA object}


### PR DESCRIPTION
This branch addresses #56, #60, and some other issues to make the API more maintainable over time

Main change adds `spatial_domain` to model query so we can query different models at seattle city, king county, and washington state (and beyond!) scales.

Conceptually smaller changes that may break the `api_service` (and possibly the model query parts of `modelServR` but I don't think so):
- two model types are now `inla_observed` and `inla_latent`, to differentiate by model objective
- the RDS file name is given by the `inla_observed` csv only for smooth models, and latent model RDS files get the `inla_latent` filename.  This reflects the underlying model definition calls.

And other minor changes to README and build script